### PR TITLE
Created a new function and added a fix to another

### DIFF
--- a/image_download.py
+++ b/image_download.py
@@ -59,11 +59,21 @@ def start_flickr_crawler(path:Path, search_text:str, n_images:int, apikey:str):
     crawler = FlickrImageCrawler(apikey,feeder_threads=2,parser_threads=2,downloader_threads=8,storage={'root_dir': path})
     crawler.crawl(tags=search_text, max_num=n_images, tag_mode='all')
 
+def dedupe_subfolders_images(dir:Path)->dict:
+    """Delete duplicate images from each dir of a parent dir"""
+    dirs = {}
+    path = Path(dir)
+    for folder in dir.iterdir():
+      if not folder.name.startswith('.'):
+        dirs[folder.name] = dedupe_images(folder)
+    return dirs
+
 def dedupe_images(image_dir:Path)->int:
     """Delete duplicate images from image_dir """
     images = {}; dups = []
     path = Path(image_dir)
     for f in path.iterdir():
+      if not Path(f).is_dir():
         h = hashfile(f)
         if h in images:
             images[h] = images[h] + 1


### PR DESCRIPTION
Created a deduce_subfolders_images function to improve the use of dedupe_images in case you want to pass a directories with lots of subdirectories containing images.
Added a condition inside dedupe_images to avoid directories instead of images.